### PR TITLE
Add message types from wx_fed official names using varcaser nam…

### DIFF
--- a/global.go
+++ b/global.go
@@ -40,6 +40,28 @@ const (
 	AppMessage   = 6
 )
 
+// https://res.wx.qq.com/a/wx_fed/webwx/res/static/js/index_c7d281c.js
+// varcaser.Caser{
+//		From: varcaser.ScreamingSnakeCase, To: varcaser.UpperCamelCaseKeepCaps}
+const (
+	MsgtypeText              = 1     // 文本消息
+	MsgtypeImage             = 3     // 图片消息
+	MsgtypeVoice             = 34    // 语音消息
+	MsgtypeVerifymsg         = 37    // 认证消息
+	MsgtypePossiblefriendMsg = 40    // 好友推荐消息
+	MsgtypeSharecard         = 42    // 名片消息
+	MsgtypeVideo             = 43    // 视频消息
+	MsgtypeEmoticon          = 47    // 表情消息
+	MsgtypeLocation          = 48    // 地理位置消息
+	MsgtypeApp               = 49    // APP消息
+	MsgtypeVoipmsg           = 50    // voip msg	//VOIP消息
+	MsgtypeVoipnotify        = 52    // voip 结束消息
+	MsgtypeVoipinvite        = 53    // voip 邀请
+	MsgtypeMicrovideo        = 62    // 小视频消息
+	MsgtypeSys               = 10000 // 系统消息
+	MsgtypeRecalled          = 10002 // 消息撤回
+)
+
 // 登录状态
 const (
 	statusSuccess = "200"


### PR DESCRIPTION

add message types from wx_fed official names using varcaser naming convention

- `wx_fed` ***official*** names from: https://res.wx.qq.com/a/wx_fed/webwx/res/static/js/index_c7d281c.js  
E.g., `MSGTYPE_TEXT`
- `varcaser` naming convention: `varcaser.Caser{ From: varcaser.ScreamingSnakeCase, To: varcaser.UpperCamelCaseKeepCaps}`. See https://github.com/danverbraganza/varcaser/issues/6.
E.g., `MsgtypeText`

