### PR TITLE
Update bot.go - 模仿官方客户端行为，间隔25秒, closes #50

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"net/url"
 	"sync"
+	"time"
 )
+
+const syncCheckDelay = 25
 
 type Bot struct {
 	ScanCallBack           func(body []byte) // 扫码回调,可获取扫码用户的头像
@@ -243,6 +246,8 @@ func (b *Bot) asyncCall() error {
 				return err
 			}
 		}
+		// 模仿官方客户端行为，间隔25秒
+		time.Sleep(syncCheckDelay * time.Second)
 	}
 	return err
 }


### PR DESCRIPTION
模仿官方客户端行为，间隔25秒

But still not quite as the 官方客户端行为 -- 

This is what happening now:

![image](https://user-images.githubusercontent.com/422244/130360883-8ab51398-8933-4e2f-ac7e-728d423dd791.png)

whereas the official client keeps the `synccheck` connection for 25 seconds, then start a fresh one. 

But at least this is a good starting point.
