### PR TITLE
更新请求参数中的时间格式

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,7 +122,7 @@ func (c *Client) GetLoginUUID() (*http.Response, error) {
 	params.Add("appid", appId)
 	params.Add("fun", "new")
 	params.Add("lang", "zh_CN")
-	params.Add("_", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("_", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 
 	path.RawQuery = params.Encode()
 	req, _ := http.NewRequest(http.MethodGet, path.String(), nil)
@@ -201,12 +201,12 @@ func (c *Client) WebWxStatusNotify(request *BaseRequest, response *WebInitRespon
 func (c *Client) SyncCheck(request *BaseRequest, info *LoginInfo, response *WebInitResponse) (*http.Response, error) {
 	path, _ := url.Parse(c.Domain.SyncHost() + synccheck)
 	params := url.Values{}
-	params.Add("r", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("r", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 	params.Add("skey", info.SKey)
 	params.Add("sid", info.WxSid)
 	params.Add("uin", strconv.FormatInt(info.WxUin, 10))
 	params.Add("deviceid", request.DeviceID)
-	params.Add("_", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("_", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 	var syncKeyStringSlice = make([]string, response.SyncKey.Count)
 	// 将SyncKey里面的元素按照特定的格式拼接起来
 	for index, item := range response.SyncKey.List {
@@ -224,7 +224,7 @@ func (c *Client) SyncCheck(request *BaseRequest, info *LoginInfo, response *WebI
 func (c *Client) WebWxGetContact(info *LoginInfo) (*http.Response, error) {
 	path, _ := url.Parse(c.Domain.BaseHost() + webwxgetcontact)
 	params := url.Values{}
-	params.Add("r", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("r", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 	params.Add("skey", info.SKey)
 	params.Add("req", "0")
 	path.RawQuery = params.Encode()
@@ -237,7 +237,7 @@ func (c *Client) WebWxBatchGetContact(members Members, request *BaseRequest) (*h
 	path, _ := url.Parse(c.Domain.BaseHost() + webwxbatchgetcontact)
 	params := url.Values{}
 	params.Add("type", "ex")
-	params.Add("r", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("r", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 	path.RawQuery = params.Encode()
 	list := NewUserDetailItemList(members)
 	content := map[string]interface{}{
@@ -509,7 +509,7 @@ func (c *Client) WebWxVerifyUser(storage *Storage, info RecommendInfo, verifyCon
 	loginInfo := storage.LoginInfo
 	path, _ := url.Parse(c.Domain.BaseHost() + webwxverifyuser)
 	params := url.Values{}
-	params.Add("r", strconv.FormatInt(time.Now().Unix(), 10))
+	params.Add("r", strconv.FormatInt(time.Now().UnixNano() / 1e6, 10))
 	params.Add("lang", "zh_CN")
 	params.Add("pass_ticket", loginInfo.PassTicket)
 	path.RawQuery = params.Encode()


### PR DESCRIPTION
微信网页版的Network里面的请求参数时间格式都是13位的，感觉这样会更好点