### PR TITLE
修复 Get "https://webpus.../synccheck?... 退出问题

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,11 +54,13 @@ func NewClient(client *http.Client) *Client {
 // 设置客户端不自动跳转
 func DefaultClient() *Client {
 	jar, _ := cookiejar.New(nil)
+	timeout := time.Duration(30 * time.Second)
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 		Jar: jar,
+		Timeout: timeout,
 	}
 	c := NewClient(client)
 	c.AddHttpHook(UserAgentHook{})


### PR DESCRIPTION
修复 Get "https://webpush.wx2.qq.com/cgi-bin/mmwebwx-bin/synccheck?...": net/http: HTTP/1.x transport connection broken: malformed HTTP status code "0" 退出问题。
代码里面的 synccheck 请求过于频繁，相信这是导致该问题的原因，解决办法是使用官方客户端的消息接受机制：
    1. 发送请求 https://webpush.wx.qq.com/cgi-bin/mmwebwx-bin/synccheck
    2. 如果没有新消息，该请求将延时 25s 后返回 window.synccheck={retcode:"0",selector:"0"}
    3. 如果有消息，将返回 window.synccheck={retcode:"0",selector:"2"}
    4. 接着继续发送第一步的请求