### PR TITLE
获取用户头像错误处理

### DIFF
--- a/client.go
+++ b/client.go
@@ -292,6 +292,7 @@ func (c *Client) WebWxGetHeadImg(user *User) (*http.Response, error) {
 		path = URL.String()
 	}
 	req, _ := http.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Content-Type", "image/jpeg")
 	return c.Do(req)
 }
 

--- a/user.go
+++ b/user.go
@@ -66,6 +66,9 @@ func (u *User) SaveAvatar(filename string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.ContentLength == 0 {
+		return fmt.Errorf("get avatar err, response content length is 0")
+	}
 	file, err := os.Create(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
获取头像有时 response contentType 的格式为 text/plain，此时 contentLength 为 0，获取头像失败。