### PR TITLE
获取用户头像错误处理

### DIFF
--- a/user.go
+++ b/user.go
@@ -66,6 +66,9 @@ func (u *User) SaveAvatar(filename string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.ContentLength == 0 {
+		return fmt.Errorf("get avatar err, response content length is 0")
+	}
 	file, err := os.Create(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
获取头像时 response contentLength 为 0，即可判断获取头像失败。response 的 Content-Type 都是 image/jpeg 。