### PR TITLE
fix save avatar

### DIFF
--- a/user.go
+++ b/user.go
@@ -75,6 +75,11 @@ func (u *User) SaveAvatar(filename string) error {
 		}
 	}
 	defer resp.Body.Close()
+	// 写文件前判断下 content length 是否是 0，不然保存的头像会出现
+	// image not loaded  try to open it externally to fix format problem 问题
+	if resp.ContentLength == 0 {
+		return fmt.Errorf("get avatar response content length is 0")
+	}
 	file, err := os.Create(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixed save avatar `image not loaded  try to open it externally to fix format problem`
if response content length is 0, an error is reported.