### PR TITLE
更新兼容mac客户端的@

### DIFF
--- a/message.go
+++ b/message.go
@@ -404,7 +404,9 @@ func (m *Message) init(bot *Bot) {
 				}
 				// 判断是不是@消息
 				atFlag := "@" + displayName + "\u2005"
-				if strings.Contains(m.Content, atFlag) {
+				// mac客户端的@是空格非\u2005
+				mac_atFlag := "@" + displayName + " "
+				if strings.Contains(m.Content, atFlag) || strings.Contains(m.Content, mac_atFlag) {
 					m.isAt = true
 					m.Content = strings.Replace(m.Content, atFlag, "", -1)
 				}


### PR DESCRIPTION
> 手机@抓包得：
@唐小风 777777777777",

解码为：
@\u5510\u5c0f\u98ce\u2005777777777777",

> mac客户端抓包得：
@唐小风 66666666666666",

解码为：
@\u5510\u5c0f\u98ce 66666666666666"
故得出，mac微信客户端的@跟手机与windows客户端有差异
考虑到大多数人用的是mac客户端，对代码进行兼容