### PR TITLE
修正与好友聊天时获取消息接收者为空的情况

### DIFF
--- a/message.go
+++ b/message.go
@@ -133,7 +133,11 @@ func (m *Message) Receiver() (*User, error) {
 		}
 		return users.First().User, nil
 	} else {
-		user, exist := m.Owner().MemberList.GetByUserName(m.ToUserName)
+		members, err := m.Owner().Members()
+		if err != nil {
+			return nil, err
+		}
+		user, exist := members.GetByUserName(m.ToUserName)
 		if !exist {
 			return nil, ErrNoSuchUserFoundError
 		}


### PR DESCRIPTION
使用中发现， 发送给好友的消息在获取消息接收者时无法得到好友的结构体
断点调试了下，发现用的`Receiver()` 方法中的 `MemberList` 为空
```go
		user, exist := m.Owner().MemberList.GetByUserName(m.ToUserName)
```
仿照群组接收者的逻辑，做如下调整即可获取到信息
```go
		members, err := m.Owner().Members()
		if err != nil {
			return nil, err
		}
		user, exist := members.GetByUserName(m.ToUserName)
```
不知是不是 Bug, 先提个 PR 先 :dog: 