### PR TITLE
修复 心跳滚动 Selector:7

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -267,8 +267,11 @@ func (b *Bot) syncMessage() ([]*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	// 更新SyncKey并且重新存入storage
-	b.Storage.Response.SyncKey = resp.SyncKey
+
+	// 更新SyncKey并且重新存入storage 如获取到的SyncKey为空则不更新
+	if resp.SyncKey.Count > 0 {
+		b.Storage.Response.SyncKey = resp.SyncKey
+	}
 	return resp.AddMsgList, nil
 }
 


### PR DESCRIPTION
修改 发送心跳时，如获取到SyncKey 数量为0时，则不更新本地SyncKey，避免清空本地SyncKey