### PR TITLE
[fix]: 修复self账号向群聊发送的消息,bot无法通过msg.Receiver获取group

### DIFF
--- a/message.go
+++ b/message.go
@@ -129,6 +129,10 @@ func (m *Message) Receiver() (*User, error) {
 		}
 		users := groups.SearchByUserName(1, username)
 		if users.Count() == 0 {
+			group := newUser(m.Owner(), username)
+			if err := group.Detail(); err == nil {
+				return group, nil
+			}
 			return nil, ErrNoSuchUserFoundError
 		}
 		return users.First().User, nil


### PR DESCRIPTION
bot账号按桌面端或网页端登录，同账号在手机端登录并向群聊发送消息，
此时bot无法获取msg的receiver，即无法获取group对象。

参考bot.updateGroups方法中“找不到, 从服务器获取”的做法，
```user, exist := members.GetByUserName(msg.FromUserName)
if !exist {
	// 找不到, 从服务器获取
	user = newUser(msg.Owner(), msg.FromUserName)
	err = user.Detail()
	b.self.members = b.self.members.Append(user)
	b.self.groups = b.self.members.Groups()
}
```

进行以下修改：
```
users := groups.SearchByUserName(1, username)
if users.Count() == 0 {
	group := newUser(m.Owner(), username)
	if err := group.Detail(); err == nil {
		return group, nil
	}
	return nil, ErrNoSuchUserFoundError
}
````

不确定是否合适，请eatmoreapple帮忙review