### PR TITLE
fix: failed to send to single member

### DIFF
--- a/user.go
+++ b/user.go
@@ -693,12 +693,12 @@ func (s *Self) ForwardMessageToGroups(msg *SentMessage, delay time.Duration, gro
 type SendMessageFunc func() (*SentMessage, error)
 
 func (s *Self) sendMessageToMember(sendMessageFunc SendMessageFunc, delay time.Duration, members ...*User) error {
-	if len(members) == 0 {
-		return nil
-	}
 	msg, err := sendMessageFunc()
 	if err != nil {
 		return err
+	}
+	if len(members) == 0 {
+		return nil
 	}
 	return s.forwardMessage(msg, delay, members...)
 }


### PR DESCRIPTION
你好，我在使用的过程中发现，当发送消息给单个好友的时候不生效。代码如下：

```golang
func PushToAll(content string) error {
	self, err := bot.GetBot().GetCurrentUser()
	if err != nil {
		return err
	}
	friends, err := self.Friends()
	if err != nil {
		return err
	}
	var pin []*openwechat.Friend
	for _, f := range friends {
		if !f.IsPin() {
			continue
		}
		pin = append(pin, f)
	}
	fmt.Println("pin", pin)
	return self.SendTextToFriends(content, time.Second, pin...)
}
```
当 `pin` 中只有一个人的时候就没有反应了。

我查看源码发现应该是这里有问题，请查阅下这个 PR。
